### PR TITLE
[Feat] EmpytSecondOption 구현

### DIFF
--- a/src/main/java/collab/Employee.java
+++ b/src/main/java/collab/Employee.java
@@ -10,11 +10,13 @@ import java.util.List;
 import java.util.Locale;
 
 public class Employee{
+    // column명도 바로 받을수 있으면 좋을것 같습니다.
     private String employeeNumber;
     private String phoneNumber;
     private String name;
     private String birthday;
     private String careerLevel;
+    private String cl;
     private String certi;
 
     private String lastName;
@@ -40,7 +42,10 @@ public class Employee{
     public Employee(List<String> commandArguments) {
         employeeNumber = commandArguments.get(0);
         name = commandArguments.get(1);
+
+        // careerLevel 이름변경 review 필요
         careerLevel = commandArguments.get(2);
+        cl = commandArguments.get(2);
         phoneNumber = commandArguments.get(3);
         birthday = commandArguments.get(4);
         certi = commandArguments.get(5);
@@ -113,9 +118,15 @@ public class Employee{
         processBirthday();
     }
 
+    // careerLevel 이름변경 review 필요
     public void setCareerLevel(String str) {
         careerLevel = str;
         validateCareerLevel();
+    }
+
+    public void setCl(String str) {
+        cl = str;
+        validateCl();
     }
 
     public void setCerti(String str) {
@@ -203,9 +214,17 @@ public class Employee{
         }
     }
 
+    // careerLevel 이름변경 review 필요
     private void validateCareerLevel(){
         List<String> careerLevelWhiteBox = Arrays.asList("CL1","CL2","CL3","CL4");
         if (!careerLevelWhiteBox.contains(careerLevel)){
+            throw new RuntimeException("Employee career level input is not valid");
+        }
+    }
+
+    private void validateCl(){
+        List<String> careerLevelWhiteBox = Arrays.asList("CL1","CL2","CL3","CL4");
+        if (!careerLevelWhiteBox.contains(cl)){
             throw new RuntimeException("Employee career level input is not valid");
         }
     }
@@ -221,7 +240,9 @@ public class Employee{
     public String getPhoneNumber() { return phoneNumber; }
     public String getName() { return name; }
     public String getBirthday() { return birthday; }
+    // careerLevel 이름변경 review 필요
     public String getCareerLevel() { return careerLevel; }
+    public String getCl() { return cl; }
     public String getCerti() { return certi; }
 
     public String getLastName() { return lastName; }
@@ -233,4 +254,14 @@ public class Employee{
     public String getBirthMonthOnly() { return birthMonthOnly; }
     public String getBirthDayOnly() { return birthDayOnly; }
 
+    public Object getField(String fieldName) throws Exception {
+        return getClass().getMethod("get" + fieldName.substring(0, 1).toUpperCase() + fieldName.substring(1)).invoke(this);
+    };
+    public String getStringField(String fieldName) throws Exception {
+        return (String)getField(fieldName);
+    };
+
+    public int getIntField(String fieldName) throws Exception {
+        return (int)getField(fieldName);
+    };
 }

--- a/src/main/java/collab/ModifyCommand.java
+++ b/src/main/java/collab/ModifyCommand.java
@@ -15,9 +15,9 @@ public class ModifyCommand extends AbstractCommand{
     @Override
     public String executeCommand(IDAO employeeDAO) {
 
-        if(getSecondOption() instanceof NoneSecondOption) {
-            return getValues((EmployeeDAO) employeeDAO);
-        }
+//        if(getSecondOption() instanceof NoneSecondOption) {
+//            return getValues((EmployeeDAO) employeeDAO);
+//        }
 
         List<Employee> list = null;
         list = getSecondOption().getFilteredList((EmployeeDAO) employeeDAO);

--- a/src/main/java/collab/SearchCommand.java
+++ b/src/main/java/collab/SearchCommand.java
@@ -20,9 +20,9 @@ public class SearchCommand extends AbstractCommand{
     @Override
     public String executeCommand(IDAO employeeDAO) {
 
-        if(getSecondOption() instanceof NoneSecondOption) {
-            return getSearchName((EmployeeDAO) employeeDAO);
-        }
+//        if(getSecondOption() instanceof NoneSecondOption) {
+//            return getSearchName((EmployeeDAO) employeeDAO);
+//        }
         List<Employee> list = getSecondOption().getFilteredList((EmployeeDAO) employeeDAO);
 
         // TODO: 임시로 조치한 것

--- a/src/main/java/collab/options/second/EmptySecondOption.java
+++ b/src/main/java/collab/options/second/EmptySecondOption.java
@@ -5,13 +5,18 @@ import collab.Employee;
 import collab.EmployeeDAO;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class EmptySecondOption extends AbstractSecondOption {
     public EmptySecondOption(List<String> optionArgument){
         super(optionArgument);
     }
     @Override
-    public List<Employee> getFilteredList(EmployeeDAO DAO) {
+    public List<Employee> getFilteredList(EmployeeDAO dao) {
+        // throws Exception 처리 이후 적용
+//        return dao.getAllItems().stream()
+//                .filter(item -> item.getStringField(getSearchColumn()).equals(getSearchValue()))
+//                .collect(Collectors.toList());
         return null;
     }
 }

--- a/src/test/java/collab/EmployeeTest.java
+++ b/src/test/java/collab/EmployeeTest.java
@@ -254,6 +254,29 @@ public class EmployeeTest {
         cmdAssertionCheck(whiteBoxCommand, employee, assertMsg, () -> {employee.setCerti(whiteBoxCommand.get(5));});
     }
 
+    @Test
+    public void employeeStringFieldPassTest() throws Exception{
+        Employee employee = new Employee(Arrays.asList("99123099","TTETHU HBO","CL4","010-4528-3059","19771208","ADV"));
+        assertTrue(employee.getStringField("employeeNumber").equals("99123099"));
+        assertTrue(employee.getStringField("name").equals("TTETHU HBO"));
+        assertTrue(employee.getStringField("cl").equals("CL4"));
+        assertTrue(employee.getStringField("phoneNum").equals("19771208"));
+        assertTrue(employee.getStringField("certi").equals("ADV"));
+    }
+
+    @Test
+    public void employeeStringFieldFailTest() throws Exception{
+        Employee employee = new Employee(Arrays.asList("99123099","TTETHU HBO","CL4","010-4528-3059","19771208","ADV"));
+        Exception exception = assertThrows(Exception.class, () -> {
+            String res = employee.getStringField("wrongField");
+        });
+        assertTrue(exception instanceof java.lang.NoSuchMethodException);
+        System.out.println(exception);
+        exception = assertThrows(Exception.class, () -> {
+            String res = employee.getStringField("realEmployeeNumber");
+        });
+        assertTrue(exception instanceof java.lang.ClassCastException);
+    }
 
 
 }

--- a/src/test/java/collab/EmployeeTest.java
+++ b/src/test/java/collab/EmployeeTest.java
@@ -257,15 +257,15 @@ public class EmployeeTest {
     @Test
     public void employeeStringFieldPassTest() throws Exception{
         Employee employee = new Employee(Arrays.asList("99123099","TTETHU HBO","CL4","010-4528-3059","19771208","ADV"));
-        assertTrue(employee.getStringField("employeeNumber").equals("99123099"));
-        assertTrue(employee.getStringField("name").equals("TTETHU HBO"));
-        assertTrue(employee.getStringField("cl").equals("CL4"));
-        assertTrue(employee.getStringField("phoneNum").equals("19771208"));
-        assertTrue(employee.getStringField("certi").equals("ADV"));
+        assertEquals(employee.getStringField("employeeNum"), "99123099");
+        assertEquals(employee.getStringField("name"), "TTETHU HBO");
+        assertEquals(employee.getStringField("cl"), "CL4");
+        assertEquals(employee.getStringField("phoneNum"), "19771208");
+        assertEquals(employee.getStringField("certi"), "ADV");
     }
 
     @Test
-    public void employeeStringFieldFailTest() throws Exception{
+    public void employeeStringFieldFailTest() {
         Employee employee = new Employee(Arrays.asList("99123099","TTETHU HBO","CL4","010-4528-3059","19771208","ADV"));
         Exception exception = assertThrows(Exception.class, () -> {
             String res = employee.getStringField("wrongField");
@@ -277,6 +277,24 @@ public class EmployeeTest {
         });
         assertTrue(exception instanceof java.lang.ClassCastException);
     }
+    @Test
+    public void employeeIntFieldPassTest() throws Exception{
+        Employee employee = new Employee(Arrays.asList("99123099","TTETHU HBO","CL4","010-4528-3059","19771208","ADV"));
+        assertEquals(employee.getIntField("realEmployeeNumber"), 1999123099);
+    }
 
+    @Test
+    public void employeeIntFieldFailTest() {
+        Employee employee = new Employee(Arrays.asList("99123099","TTETHU HBO","CL4","010-4528-3059","19771208","ADV"));
+        Exception exception = assertThrows(Exception.class, () -> {
+            String res = employee.getStringField("wrongField");
+        });
+        assertTrue(exception instanceof java.lang.NoSuchMethodException);
+        System.out.println(exception);
+        exception = assertThrows(Exception.class, () -> {
+            int res = employee.getIntField("name");
+        });
+        assertTrue(exception instanceof java.lang.ClassCastException);
+    }
 
 }


### PR DESCRIPTION
- EmptySecondOption 구현. 에러로 인한여 주석 처리.
- Employee 객체 field getter 생성
- Employee 내에서 실제 Column 값을 처리 가능하도록 변경 필요.
- Command에서는 Option 의 결과를 그대로 받아서 사용
- Parser 에서 적절한 Option 객체를 생성해서 전달
- 추후 EmpytSecondOption 객체는 세부 조건 없이 전체 조건을 검색 한다는 의미의 객체 이름으로 리팩토링 필요